### PR TITLE
Add weather dashboard with Open Meteo API integration

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,12 @@ const demos = [
     description: 'Table with select filter.',
     category: 'Tables',
   },
+  {
+    route: '/weather',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather data with Open Meteo API.',
+    category: 'Dashboards',
+  },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
 ];

--- a/src/pages/weather/app.tsx
+++ b/src/pages/weather/app.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, HelpPanelProvider, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { WeatherContent } from './components/content';
+import { WeatherHeader, WeatherMainInfo } from './components/header';
+import { WeatherSideNavigation } from './components/side-navigation';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+export function App() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState<React.ReactNode>(() => <WeatherMainInfo />);
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+
+  const handleToolsContentChange = (content: React.ReactNode) => {
+    setToolsOpen(true);
+    setToolsContent(content);
+    appLayout.current?.focusToolsClose();
+  };
+
+  return (
+    <HelpPanelProvider value={handleToolsContentChange}>
+      <CustomAppLayout
+        ref={appLayout}
+        content={
+          <SpaceBetween size="m">
+            <WeatherHeader actions={<Button variant="primary">Refresh Weather</Button>} />
+            <WeatherContent />
+          </SpaceBetween>
+        }
+        breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+        navigation={<WeatherSideNavigation />}
+        tools={toolsContent}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+      />
+    </HelpPanelProvider>
+  );
+}

--- a/src/pages/weather/components/content.tsx
+++ b/src/pages/weather/components/content.tsx
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState, useEffect } from 'react';
+
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Alert from '@cloudscape-design/components/alert';
+import Spinner from '@cloudscape-design/components/spinner';
+import Box from '@cloudscape-design/components/box';
+
+import { WeatherAPI, WeatherData, WeatherLocation, DEFAULT_LOCATIONS } from '../services/weather-api';
+import { CurrentWeatherWidget } from '../widgets/current-weather';
+import { HourlyForecastWidget } from '../widgets/hourly-forecast';
+import { DailyForecastWidget } from '../widgets/daily-forecast';
+import { LocationSelector } from '../widgets/location-selector';
+
+export function WeatherContent() {
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentLocation, setCurrentLocation] = useState<WeatherLocation>(DEFAULT_LOCATIONS[0]);
+
+  const fetchWeatherData = async (location: WeatherLocation) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await WeatherAPI.getCurrentWeather(location);
+      setWeatherData(data);
+    } catch (err) {
+      setError('Failed to fetch weather data. Please try again.');
+      console.error('Weather API error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWeatherData(currentLocation);
+  }, [currentLocation]);
+
+  const handleLocationChange = (location: WeatherLocation) => {
+    setCurrentLocation(location);
+  };
+
+  if (loading && !weatherData) {
+    return (
+      <Box textAlign="center" padding="xxl">
+        <SpaceBetween size="m" alignItems="center">
+          <Spinner size="large" />
+          <Box variant="p">Loading weather data...</Box>
+        </SpaceBetween>
+      </Box>
+    );
+  }
+
+  return (
+    <SpaceBetween size="l">
+      {error && <Alert type="error">{error}</Alert>}
+
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 4, xl: 4 } },
+          { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 8, xl: 8 } },
+        ]}
+      >
+        <LocationSelector currentLocation={currentLocation} onLocationChange={handleLocationChange} loading={loading} />
+        {weatherData && <CurrentWeatherWidget weather={weatherData.current} location={weatherData.location} />}
+      </Grid>
+
+      {weatherData && (
+        <Grid
+          gridDefinition={[
+            { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 6, xl: 6 } },
+            { colspan: { default: 12, xs: 12, s: 12, m: 12, l: 6, xl: 6 } },
+          ]}
+        >
+          <HourlyForecastWidget forecast={weatherData.hourly} />
+          <DailyForecastWidget forecast={weatherData.daily} />
+        </Grid>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather/components/header.tsx
+++ b/src/pages/weather/components/header.tsx
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Header from '@cloudscape-design/components/header';
+import HelpPanel from '@cloudscape-design/components/help-panel';
+import Link from '@cloudscape-design/components/link';
+
+export function WeatherHeader({ actions }: { actions: React.ReactNode }) {
+  return (
+    <Header variant="h1" actions={actions}>
+      Weather Dashboard
+    </Header>
+  );
+}
+
+export function WeatherMainInfo() {
+  return (
+    <HelpPanel header={<h2>Weather Dashboard</h2>}>
+      <p>
+        This weather dashboard displays real-time weather information using the Open Meteo API. View current conditions,
+        hourly forecasts, and weekly predictions for any location worldwide.
+      </p>
+      <h3>Features</h3>
+      <ul>
+        <li>Current weather conditions</li>
+        <li>Hourly forecasts for the next 24 hours</li>
+        <li>7-day weather outlook</li>
+        <li>Multiple location support</li>
+        <li>Temperature, humidity, wind speed, and precipitation data</li>
+      </ul>
+      <h3>Data Source</h3>
+      <p>
+        Weather data is provided by{' '}
+        <Link external href="https://open-meteo.com">
+          Open Meteo API
+        </Link>
+        , a free and open-source weather service.
+      </p>
+    </HelpPanel>
+  );
+}

--- a/src/pages/weather/components/side-navigation.tsx
+++ b/src/pages/weather/components/side-navigation.tsx
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import SideNavigation from '@cloudscape-design/components/side-navigation';
+
+export function WeatherSideNavigation() {
+  return (
+    <SideNavigation
+      header={{ text: 'Weather Dashboard', href: '/weather' }}
+      items={[
+        {
+          type: 'section',
+          text: 'Current Weather',
+          items: [
+            { type: 'link', text: 'Overview', href: '#overview' },
+            { type: 'link', text: 'Current Conditions', href: '#current' },
+          ],
+        },
+        {
+          type: 'section',
+          text: 'Forecasts',
+          items: [
+            { type: 'link', text: 'Hourly Forecast', href: '#hourly' },
+            { type: 'link', text: 'Daily Forecast', href: '#daily' },
+          ],
+        },
+        {
+          type: 'section',
+          text: 'Locations',
+          items: [
+            { type: 'link', text: 'Add Location', href: '#add-location' },
+            { type: 'link', text: 'Manage Locations', href: '#manage' },
+          ],
+        },
+      ]}
+    />
+  );
+}

--- a/src/pages/weather/index.tsx
+++ b/src/pages/weather/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}

--- a/src/pages/weather/services/weather-api.ts
+++ b/src/pages/weather/services/weather-api.ts
@@ -1,0 +1,178 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface WeatherLocation {
+  latitude: number;
+  longitude: number;
+  name: string;
+  country?: string;
+  timezone?: string;
+}
+
+export interface CurrentWeather {
+  temperature: number;
+  windSpeed: number;
+  windDirection: number;
+  humidity: number;
+  precipitation: number;
+  weatherCode: number;
+  time: string;
+}
+
+export interface HourlyForecast {
+  time: string[];
+  temperature: number[];
+  humidity: number[];
+  precipitation: number[];
+  windSpeed: number[];
+}
+
+export interface DailyForecast {
+  time: string[];
+  temperatureMax: number[];
+  temperatureMin: number[];
+  precipitation: number[];
+  windSpeedMax: number[];
+  weatherCode: number[];
+}
+
+export interface WeatherData {
+  current: CurrentWeather;
+  hourly: HourlyForecast;
+  daily: DailyForecast;
+  location: WeatherLocation;
+}
+
+export class WeatherAPI {
+  private static readonly BASE_URL = 'https://api.open-meteo.com/v1';
+
+  static async getCurrentWeather(location: WeatherLocation): Promise<WeatherData> {
+    const params = new URLSearchParams({
+      latitude: location.latitude.toString(),
+      longitude: location.longitude.toString(),
+      current: [
+        'temperature_2m',
+        'relative_humidity_2m',
+        'precipitation',
+        'weather_code',
+        'wind_speed_10m',
+        'wind_direction_10m',
+      ].join(','),
+      hourly: ['temperature_2m', 'relative_humidity_2m', 'precipitation', 'wind_speed_10m'].join(','),
+      daily: [
+        'temperature_2m_max',
+        'temperature_2m_min',
+        'precipitation_sum',
+        'wind_speed_10m_max',
+        'weather_code',
+      ].join(','),
+      timezone: 'auto',
+      forecast_days: '7',
+    });
+
+    const response = await fetch(`${this.BASE_URL}/forecast?${params}`);
+
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    return {
+      current: {
+        temperature: data.current.temperature_2m,
+        windSpeed: data.current.wind_speed_10m,
+        windDirection: data.current.wind_direction_10m,
+        humidity: data.current.relative_humidity_2m,
+        precipitation: data.current.precipitation,
+        weatherCode: data.current.weather_code,
+        time: data.current.time,
+      },
+      hourly: {
+        time: data.hourly.time.slice(0, 24), // Next 24 hours
+        temperature: data.hourly.temperature_2m.slice(0, 24),
+        humidity: data.hourly.relative_humidity_2m.slice(0, 24),
+        precipitation: data.hourly.precipitation.slice(0, 24),
+        windSpeed: data.hourly.wind_speed_10m.slice(0, 24),
+      },
+      daily: {
+        time: data.daily.time,
+        temperatureMax: data.daily.temperature_2m_max,
+        temperatureMin: data.daily.temperature_2m_min,
+        precipitation: data.daily.precipitation_sum,
+        windSpeedMax: data.daily.wind_speed_10m_max,
+        weatherCode: data.daily.weather_code,
+      },
+      location,
+    };
+  }
+
+  static async searchLocations(query: string): Promise<WeatherLocation[]> {
+    const params = new URLSearchParams({
+      name: query,
+      count: '10',
+      language: 'en',
+      format: 'json',
+    });
+
+    const response = await fetch(`https://geocoding-api.open-meteo.com/v1/search?${params}`);
+
+    if (!response.ok) {
+      throw new Error(`Geocoding API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    return (data.results || []).map((result: any) => ({
+      latitude: result.latitude,
+      longitude: result.longitude,
+      name: result.name,
+      country: result.country,
+      timezone: result.timezone,
+    }));
+  }
+
+  static getWeatherDescription(weatherCode: number): string {
+    const weatherCodes: Record<number, string> = {
+      0: 'Clear sky',
+      1: 'Mainly clear',
+      2: 'Partly cloudy',
+      3: 'Overcast',
+      45: 'Fog',
+      48: 'Depositing rime fog',
+      51: 'Light drizzle',
+      53: 'Moderate drizzle',
+      55: 'Dense drizzle',
+      56: 'Light freezing drizzle',
+      57: 'Dense freezing drizzle',
+      61: 'Slight rain',
+      63: 'Moderate rain',
+      65: 'Heavy rain',
+      66: 'Light freezing rain',
+      67: 'Heavy freezing rain',
+      71: 'Slight snow fall',
+      73: 'Moderate snow fall',
+      75: 'Heavy snow fall',
+      77: 'Snow grains',
+      80: 'Slight rain showers',
+      81: 'Moderate rain showers',
+      82: 'Violent rain showers',
+      85: 'Slight snow showers',
+      86: 'Heavy snow showers',
+      95: 'Thunderstorm',
+      96: 'Thunderstorm with slight hail',
+      99: 'Thunderstorm with heavy hail',
+    };
+
+    return weatherCodes[weatherCode] || 'Unknown';
+  }
+}
+
+// Default locations
+export const DEFAULT_LOCATIONS: WeatherLocation[] = [
+  { latitude: 40.7128, longitude: -74.006, name: 'New York', country: 'United States' },
+  { latitude: 51.5074, longitude: -0.1278, name: 'London', country: 'United Kingdom' },
+  { latitude: 48.8566, longitude: 2.3522, name: 'Paris', country: 'France' },
+  { latitude: 35.6762, longitude: 139.6503, name: 'Tokyo', country: 'Japan' },
+  { latitude: -33.8688, longitude: 151.2093, name: 'Sydney', country: 'Australia' },
+];

--- a/src/pages/weather/widgets/current-weather.tsx
+++ b/src/pages/weather/widgets/current-weather.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+
+import { CurrentWeather, WeatherLocation, WeatherAPI } from '../services/weather-api';
+
+interface CurrentWeatherWidgetProps {
+  weather: CurrentWeather;
+  location: WeatherLocation;
+}
+
+export function CurrentWeatherWidget({ weather, location }: CurrentWeatherWidgetProps) {
+  const formatTime = (timeString: string) => {
+    return new Date(timeString).toLocaleString();
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={`${location.name}, ${location.country || ''}`}>
+          Current Weather
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <ColumnLayout columns={4} variant="text-grid">
+          <div>
+            <Box variant="awsui-key-label">Temperature</Box>
+            <Box fontSize="heading-xl" fontWeight="bold">
+              {Math.round(weather.temperature)}°C
+            </Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Conditions</Box>
+            <Badge color="blue">{WeatherAPI.getWeatherDescription(weather.weatherCode)}</Badge>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Humidity</Box>
+            <Box fontSize="heading-m">{weather.humidity}%</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Wind Speed</Box>
+            <Box fontSize="heading-m">{Math.round(weather.windSpeed)} km/h</Box>
+          </div>
+        </ColumnLayout>
+
+        <ColumnLayout columns={3} variant="text-grid">
+          <div>
+            <Box variant="awsui-key-label">Wind Direction</Box>
+            <Box fontSize="heading-s">{weather.windDirection}°</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Precipitation</Box>
+            <Box fontSize="heading-s">{weather.precipitation} mm</Box>
+          </div>
+          <div>
+            <Box variant="awsui-key-label">Last Updated</Box>
+            <Box fontSize="heading-s">{formatTime(weather.time)}</Box>
+          </div>
+        </ColumnLayout>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/pages/weather/widgets/daily-forecast.tsx
+++ b/src/pages/weather/widgets/daily-forecast.tsx
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Cards from '@cloudscape-design/components/cards';
+import Box from '@cloudscape-design/components/box';
+import Badge from '@cloudscape-design/components/badge';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { DailyForecast, WeatherAPI } from '../services/weather-api';
+
+interface DailyForecastWidgetProps {
+  forecast: DailyForecast;
+}
+
+export function DailyForecastWidget({ forecast }: DailyForecastWidgetProps) {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (date.toDateString() === today.toDateString()) {
+      return 'Today';
+    } else if (date.toDateString() === tomorrow.toDateString()) {
+      return 'Tomorrow';
+    } else {
+      return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+    }
+  };
+
+  const items = forecast.time.map((time, index) => ({
+    date: time,
+    displayDate: formatDate(time),
+    temperatureMax: forecast.temperatureMax[index],
+    temperatureMin: forecast.temperatureMin[index],
+    precipitation: forecast.precipitation[index],
+    windSpeedMax: forecast.windSpeedMax[index],
+    weatherCode: forecast.weatherCode[index],
+    conditions: WeatherAPI.getWeatherDescription(forecast.weatherCode[index]),
+  }));
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="7-day outlook">
+          Daily Forecast
+        </Header>
+      }
+    >
+      <Cards
+        ariaLabels={{
+          itemSelectionLabel: (e, n) => `select ${n.displayDate}`,
+          selectionGroupLabel: 'Daily forecast selection',
+        }}
+        cardDefinition={{
+          header: item => (
+            <Box fontSize="heading-s" fontWeight="bold">
+              {item.displayDate}
+            </Box>
+          ),
+          sections: [
+            {
+              id: 'temperature',
+              content: item => (
+                <SpaceBetween size="xs" direction="horizontal">
+                  <Box variant="span" fontSize="heading-m" fontWeight="bold">
+                    {Math.round(item.temperatureMax)}°
+                  </Box>
+                  <Box variant="span" color="text-body-secondary">
+                    / {Math.round(item.temperatureMin)}°
+                  </Box>
+                </SpaceBetween>
+              ),
+            },
+            {
+              id: 'conditions',
+              content: item => <Badge color="blue">{item.conditions}</Badge>,
+            },
+            {
+              id: 'details',
+              content: item => (
+                <SpaceBetween size="xs">
+                  <Box variant="small">Precipitation: {item.precipitation} mm</Box>
+                  <Box variant="small">Wind: {Math.round(item.windSpeedMax)} km/h</Box>
+                </SpaceBetween>
+              ),
+            },
+          ],
+        }}
+        cardsPerRow={[
+          { cards: 1, minWidth: 0 },
+          { cards: 2, minWidth: 400 },
+          { cards: 3, minWidth: 600 },
+          { cards: 4, minWidth: 800 },
+          { cards: 7, minWidth: 1200 },
+        ]}
+        items={items}
+        loadingText="Loading forecast..."
+        trackBy="date"
+        visibleSections={['temperature', 'conditions', 'details']}
+        empty={
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No forecast data available
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather/widgets/hourly-forecast.tsx
+++ b/src/pages/weather/widgets/hourly-forecast.tsx
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Table from '@cloudscape-design/components/table';
+import Badge from '@cloudscape-design/components/badge';
+
+import { HourlyForecast } from '../services/weather-api';
+
+interface HourlyForecastWidgetProps {
+  forecast: HourlyForecast;
+}
+
+export function HourlyForecastWidget({ forecast }: HourlyForecastWidgetProps) {
+  const formatHour = (timeString: string) => {
+    return new Date(timeString).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const items = forecast.time.map((time, index) => ({
+    time,
+    temperature: forecast.temperature[index],
+    humidity: forecast.humidity[index],
+    precipitation: forecast.precipitation[index],
+    windSpeed: forecast.windSpeed[index],
+  }));
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Next 24 hours">
+          Hourly Forecast
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: 'time',
+            header: 'Time',
+            cell: item => formatHour(item.time),
+            sortingField: 'time',
+          },
+          {
+            id: 'temperature',
+            header: 'Temperature',
+            cell: item => `${Math.round(item.temperature)}°C`,
+            sortingField: 'temperature',
+          },
+          {
+            id: 'humidity',
+            header: 'Humidity',
+            cell: item => `${item.humidity}%`,
+            sortingField: 'humidity',
+          },
+          {
+            id: 'precipitation',
+            header: 'Precipitation',
+            cell: item => <Badge color={item.precipitation > 0 ? 'blue' : 'grey'}>{item.precipitation} mm</Badge>,
+            sortingField: 'precipitation',
+          },
+          {
+            id: 'windSpeed',
+            header: 'Wind Speed',
+            cell: item => `${Math.round(item.windSpeed)} km/h`,
+            sortingField: 'windSpeed',
+          },
+        ]}
+        items={items.slice(0, 12)} // Show next 12 hours
+        loadingText="Loading forecast..."
+        sortingDisabled
+        empty="No forecast data available"
+        variant="embedded"
+      />
+    </Container>
+  );
+}

--- a/src/pages/weather/widgets/location-selector.tsx
+++ b/src/pages/weather/widgets/location-selector.tsx
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Select from '@cloudscape-design/components/select';
+import Button from '@cloudscape-design/components/button';
+import Input from '@cloudscape-design/components/input';
+import FormField from '@cloudscape-design/components/form-field';
+import Alert from '@cloudscape-design/components/alert';
+
+import { WeatherLocation, WeatherAPI, DEFAULT_LOCATIONS } from '../services/weather-api';
+
+interface LocationSelectorProps {
+  currentLocation: WeatherLocation;
+  onLocationChange: (location: WeatherLocation) => void;
+  loading?: boolean;
+}
+
+export function LocationSelector({ currentLocation, onLocationChange, loading }: LocationSelectorProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<WeatherLocation[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async () => {
+    if (!searchQuery.trim()) return;
+
+    setSearching(true);
+    setError(null);
+
+    try {
+      const results = await WeatherAPI.searchLocations(searchQuery);
+      setSearchResults(results);
+    } catch (err) {
+      setError('Failed to search locations. Please try again.');
+      console.error('Location search error:', err);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleLocationSelect = (location: WeatherLocation) => {
+    onLocationChange(location);
+    setSearchResults([]);
+    setSearchQuery('');
+  };
+
+  const allLocations = [...DEFAULT_LOCATIONS, ...searchResults];
+  const uniqueLocations = allLocations.filter(
+    (location, index, self) =>
+      index === self.findIndex(l => l.latitude === location.latitude && l.longitude === location.longitude),
+  );
+
+  const locationOptions = uniqueLocations.map(location => ({
+    label: `${location.name}, ${location.country || ''}`,
+    value: JSON.stringify(location),
+    description: `${location.latitude.toFixed(2)}, ${location.longitude.toFixed(2)}`,
+  }));
+
+  const selectedOption = locationOptions.find(option => {
+    const optionLocation = JSON.parse(option.value);
+    return (
+      optionLocation.latitude === currentLocation.latitude && optionLocation.longitude === currentLocation.longitude
+    );
+  });
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description="Search and select a location for weather data">
+          Location
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {error && <Alert type="error">{error}</Alert>}
+
+        <FormField label="Search for a location">
+          <SpaceBetween size="xs" direction="horizontal">
+            <Input
+              value={searchQuery}
+              onChange={({ detail }) => setSearchQuery(detail.value)}
+              placeholder="Enter city name..."
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  handleSearch();
+                }
+              }}
+            />
+            <Button onClick={handleSearch} loading={searching} iconName="search">
+              Search
+            </Button>
+          </SpaceBetween>
+        </FormField>
+
+        <FormField label="Select location">
+          <Select
+            selectedOption={selectedOption || null}
+            onChange={({ detail }) => {
+              if (detail.selectedOption) {
+                const location = JSON.parse(detail.selectedOption.value!);
+                handleLocationSelect(location);
+              }
+            }}
+            options={locationOptions}
+            placeholder="Choose a location"
+            loadingText="Loading locations..."
+            disabled={loading}
+            expandToViewport
+          />
+        </FormField>
+      </SpaceBetween>
+    </Container>
+  );
+}


### PR DESCRIPTION
Add a new weather dashboard page that displays real-time weather data using the Open Meteo API.

Changes include:
- Add weather dashboard entry to main demos list
- Create weather dashboard app with layout components
- Implement weather content with current conditions and forecasts
- Add header, side navigation, and help panel components
- Create weather API service with location search and data fetching
- Add current weather widget displaying temperature, humidity, and conditions
- Implement hourly forecast table showing next 12 hours
- Create daily forecast cards with 7-day outlook
- Add location selector with search functionality and predefined locations

The dashboard provides current weather conditions, hourly forecasts, and daily forecasts with support for multiple locations worldwide.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/514d22a1cb1b447296fd2a00d4173016/zenith-home)

👀 [Preview Link](https://514d22a1cb1b447296fd2a00d4173016-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>514d22a1cb1b447296fd2a00d4173016</projectId>-->
<!--<branchName>zenith-home</branchName>-->