### PR TITLE
feat: Add network administration dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic, credit usage, and device management dashboard.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -56,6 +56,7 @@ export function App() {
                   {
                     type: 'warning',
                     dismissible: true,
+                    dismissLabel: 'Dismiss',
                     content: 'This is a warning message',
                     id: 'warning-1',
                   },
@@ -65,7 +66,7 @@ export function App() {
           }
         >
           <SpaceBetween size="l">
-            <div className="search-pagination-wrapper">
+            <Container>
               <Grid
                 gridDefinition={[
                   { colspan: { default: 12, s: 8 } },
@@ -89,7 +90,7 @@ export function App() {
                   </SpaceBetween>
                 </div>
               </Grid>
-            </div>
+            </Container>
 
             <Grid
               gridDefinition={[

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -18,6 +18,7 @@ import Icon from '@cloudscape-design/components/icon';
 import { NetworkTrafficChart } from './components/network-traffic-chart';
 import { CreditUsageChart } from './components/credit-usage-chart';
 import { DevicesTable } from './components/devices-table';
+import './styles.css';
 
 export function App() {
   const [filteringText, setFilteringText] = useState('');

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -67,12 +67,7 @@ export function App() {
         >
           <SpaceBetween size="l">
             <Container>
-              <Grid
-                gridDefinition={[
-                  { colspan: { default: 12, s: 8 } },
-                  { colspan: { default: 12, s: 4 } },
-                ]}
-              >
+              <Grid gridDefinition={[{ colspan: { default: 12, s: 8 } }, { colspan: { default: 12, s: 4 } }]}>
                 <TextFilter
                   filteringText={filteringText}
                   filteringPlaceholder="Placeholder"
@@ -92,12 +87,7 @@ export function App() {
               </Grid>
             </Container>
 
-            <Grid
-              gridDefinition={[
-                { colspan: { default: 12, m: 6 } },
-                { colspan: { default: 12, m: 6 } },
-              ]}
-            >
+            <Grid gridDefinition={[{ colspan: { default: 12, m: 6 } }, { colspan: { default: 12, m: 6 } }]}>
               <NetworkTrafficChart />
               <CreditUsageChart />
             </Grid>

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Icon from '@cloudscape-design/components/icon';
+
+import { NetworkTrafficChart } from './components/network-traffic-chart';
+import { CreditUsageChart } from './components/credit-usage-chart';
+import { DevicesTable } from './components/devices-table';
+
+export function App() {
+  const [filteringText, setFilteringText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+
+  return (
+    <AppLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Service', href: '#' },
+            { text: 'Administrative Dashboard', href: '#' },
+          ]}
+        />
+      }
+      navigationHide
+      toolsHide
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <Header
+                variant="h1"
+                description="Network Traffic, Credit Usage, and Your Devices"
+                actions={
+                  <Button variant="primary" iconName="external" iconAlign="right">
+                    Refresh Data
+                  </Button>
+                }
+              >
+                Network Adminstration Dashboard
+              </Header>
+              <Flashbar
+                items={[
+                  {
+                    type: 'warning',
+                    dismissible: true,
+                    content: 'This is a warning message',
+                    id: 'warning-1',
+                  },
+                ]}
+              />
+            </SpaceBetween>
+          }
+        >
+          <SpaceBetween size="l">
+            <div className="search-pagination-wrapper">
+              <Grid
+                gridDefinition={[
+                  { colspan: { default: 12, s: 8 } },
+                  { colspan: { default: 12, s: 4 } },
+                ]}
+              >
+                <TextFilter
+                  filteringText={filteringText}
+                  filteringPlaceholder="Placeholder"
+                  filteringAriaLabel="Filter content"
+                  onChange={({ detail }) => setFilteringText(detail.filteringText)}
+                />
+                <div className="pagination-controls">
+                  <SpaceBetween size="xs" direction="horizontal" alignItems="center">
+                    <Pagination
+                      currentPageIndex={currentPageIndex}
+                      pagesCount={5}
+                      onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                    />
+                    <Button iconName="settings" variant="icon" />
+                  </SpaceBetween>
+                </div>
+              </Grid>
+            </div>
+
+            <Grid
+              gridDefinition={[
+                { colspan: { default: 12, m: 6 } },
+                { colspan: { default: 12, m: 6 } },
+              ]}
+            >
+              <NetworkTrafficChart />
+              <CreditUsageChart />
+            </Grid>
+
+            <DevicesTable />
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/network-dashboard/components/credit-usage-chart.tsx
+++ b/src/pages/network-dashboard/components/credit-usage-chart.tsx
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+
+export function CreditUsageChart() {
+  const series = [
+    {
+      title: 'Site 1',
+      type: 'bar' as const,
+      data: [
+        { x: 'x1', y: 183 },
+        { x: 'x2', y: 257 },
+        { x: 'x3', y: 213 },
+        { x: 'x4', y: 122 },
+        { x: 'x5', y: 210 },
+      ],
+    },
+  ];
+
+  return (
+    <Container>
+      <BarChart
+        series={series}
+        height={300}
+        ariaLabel="Credit usage bar chart"
+        xTitle="Day"
+        yTitle="Credit Usage"
+        legendTitle="Legend"
+        i18nStrings={{
+          yTickFormatter: (value) => `y${value}`,
+        }}
+        hideFilter
+        statusType="finished"
+      />
+    </Container>
+  );
+}

--- a/src/pages/network-dashboard/components/credit-usage-chart.tsx
+++ b/src/pages/network-dashboard/components/credit-usage-chart.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 
 import BarChart from '@cloudscape-design/components/bar-chart';
-import Box from '@cloudscape-design/components/box';
 import Container from '@cloudscape-design/components/container';
 
 export function CreditUsageChart() {
@@ -29,10 +28,6 @@ export function CreditUsageChart() {
         ariaLabel="Credit usage bar chart"
         xTitle="Day"
         yTitle="Credit Usage"
-        legendTitle="Legend"
-        i18nStrings={{
-          yTickFormatter: (value) => `y${value}`,
-        }}
         hideFilter
         statusType="finished"
       />

--- a/src/pages/network-dashboard/components/devices-table.tsx
+++ b/src/pages/network-dashboard/components/devices-table.tsx
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+
+interface Device {
+  id: string;
+  column1: string;
+  column2: string;
+  column3: string;
+  column4: string;
+  column5: string;
+  column6: string;
+  column7: string;
+}
+
+const generateDevices = (): Device[] => {
+  const devices: Device[] = [];
+  for (let i = 1; i <= 12; i++) {
+    devices.push({
+      id: `device-${i}`,
+      column1: 'Cell Value',
+      column2: 'Cell Value',
+      column3: 'Cell Value',
+      column4: 'Cell Value',
+      column5: 'Cell Value',
+      column6: 'Cell Value',
+      column7: 'Cell Value',
+    });
+  }
+  return devices;
+};
+
+export function DevicesTable() {
+  const [selectedItems, setSelectedItems] = useState<Device[]>([]);
+  const devices = generateDevices();
+
+  const columnDefinitions = [
+    {
+      id: 'column1',
+      header: 'Column header',
+      cell: (item: Device) => item.column1,
+      sortingField: 'column1',
+    },
+    {
+      id: 'column2',
+      header: 'Column header',
+      cell: (item: Device) => item.column2,
+      sortingField: 'column2',
+    },
+    {
+      id: 'column3',
+      header: 'Column header',
+      cell: (item: Device) => item.column3,
+      sortingField: 'column3',
+    },
+    {
+      id: 'column4',
+      header: 'Column header',
+      cell: (item: Device) => item.column4,
+      sortingField: 'column4',
+    },
+    {
+      id: 'column5',
+      header: 'Column header',
+      cell: (item: Device) => item.column5,
+      sortingField: 'column5',
+    },
+    {
+      id: 'column6',
+      header: 'Column header',
+      cell: (item: Device) => item.column6,
+      sortingField: 'column6',
+    },
+    {
+      id: 'column7',
+      header: 'Column header',
+      cell: (item: Device) => item.column7,
+      sortingField: 'column7',
+    },
+  ];
+
+  return (
+    <Table
+      columnDefinitions={columnDefinitions}
+      items={devices}
+      selectionType="multi"
+      selectedItems={selectedItems}
+      onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+      header={
+        <Header
+          variant="h2"
+          description="Devices on your local network"
+          actions={
+            <Button variant="primary" iconName="external" iconAlign="right">
+              Add Device
+            </Button>
+          }
+        >
+          My Devices
+        </Header>
+      }
+      empty={
+        <Box textAlign="center" color="inherit">
+          <b>No devices</b>
+          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+            No devices to display.
+          </Box>
+          <Button>Add device</Button>
+        </Box>
+      }
+    />
+  );
+}

--- a/src/pages/network-dashboard/components/network-traffic-chart.tsx
+++ b/src/pages/network-dashboard/components/network-traffic-chart.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+
+import AreaChart from '@cloudscape-design/components/area-chart';
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+
+export function NetworkTrafficChart() {
+  const series = [
+    {
+      title: 'Site 1',
+      type: 'area' as const,
+      data: [
+        { x: new Date(2023, 0, 1), y: 3 },
+        { x: new Date(2023, 0, 2), y: 3.2 },
+        { x: new Date(2023, 0, 3), y: 3.5 },
+        { x: new Date(2023, 0, 4), y: 3.8 },
+        { x: new Date(2023, 0, 5), y: 4.2 },
+        { x: new Date(2023, 0, 6), y: 4.5 },
+        { x: new Date(2023, 0, 7), y: 4.8 },
+        { x: new Date(2023, 0, 8), y: 5 },
+        { x: new Date(2023, 0, 9), y: 5.2 },
+        { x: new Date(2023, 0, 10), y: 5 },
+        { x: new Date(2023, 0, 11), y: 4.8 },
+        { x: new Date(2023, 0, 12), y: 4.5 },
+      ],
+      valueFormatter: (value: number) => `${value.toFixed(1)}`,
+    },
+    {
+      title: 'Site 2',
+      type: 'area' as const,
+      data: [
+        { x: new Date(2023, 0, 1), y: 2 },
+        { x: new Date(2023, 0, 2), y: 2.2 },
+        { x: new Date(2023, 0, 3), y: 2.1 },
+        { x: new Date(2023, 0, 4), y: 1.9 },
+        { x: new Date(2023, 0, 5), y: 2.3 },
+        { x: new Date(2023, 0, 6), y: 3 },
+        { x: new Date(2023, 0, 7), y: 3.5 },
+        { x: new Date(2023, 0, 8), y: 3.4 },
+        { x: new Date(2023, 0, 9), y: 3.2 },
+        { x: new Date(2023, 0, 10), y: 2.8 },
+        { x: new Date(2023, 0, 11), y: 2.5 },
+        { x: new Date(2023, 0, 12), y: 2.3 },
+      ],
+      valueFormatter: (value: number) => `${value.toFixed(1)}`,
+    },
+  ];
+
+  return (
+    <Container>
+      <AreaChart
+        series={series}
+        xDomain={[new Date(2023, 0, 1), new Date(2023, 0, 12)]}
+        yDomain={[0, 6]}
+        height={300}
+        ariaLabel="Network traffic area chart"
+        xTitle="Day"
+        yTitle="Network traffic"
+        legendTitle="Legend"
+        i18nStrings={{
+          xTickFormatter: (value) => {
+            const date = value as Date;
+            return `x${date.getDate()}`;
+          },
+          yTickFormatter: (value) => `y${value}`,
+        }}
+        hideFilter
+        statusType="finished"
+      />
+    </Container>
+  );
+}

--- a/src/pages/network-dashboard/components/network-traffic-chart.tsx
+++ b/src/pages/network-dashboard/components/network-traffic-chart.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 
 import AreaChart from '@cloudscape-design/components/area-chart';
-import Box from '@cloudscape-design/components/box';
 import Container from '@cloudscape-design/components/container';
 
 export function NetworkTrafficChart() {
@@ -12,39 +11,37 @@ export function NetworkTrafficChart() {
       title: 'Site 1',
       type: 'area' as const,
       data: [
-        { x: new Date(2023, 0, 1), y: 3 },
-        { x: new Date(2023, 0, 2), y: 3.2 },
-        { x: new Date(2023, 0, 3), y: 3.5 },
-        { x: new Date(2023, 0, 4), y: 3.8 },
-        { x: new Date(2023, 0, 5), y: 4.2 },
-        { x: new Date(2023, 0, 6), y: 4.5 },
-        { x: new Date(2023, 0, 7), y: 4.8 },
-        { x: new Date(2023, 0, 8), y: 5 },
-        { x: new Date(2023, 0, 9), y: 5.2 },
-        { x: new Date(2023, 0, 10), y: 5 },
-        { x: new Date(2023, 0, 11), y: 4.8 },
-        { x: new Date(2023, 0, 12), y: 4.5 },
+        { x: 'x1', y: 3 },
+        { x: 'x2', y: 3.2 },
+        { x: 'x3', y: 3.5 },
+        { x: 'x4', y: 3.8 },
+        { x: 'x5', y: 4.2 },
+        { x: 'x6', y: 4.5 },
+        { x: 'x7', y: 4.8 },
+        { x: 'x8', y: 5 },
+        { x: 'x9', y: 5.2 },
+        { x: 'x10', y: 5 },
+        { x: 'x11', y: 4.8 },
+        { x: 'x12', y: 4.5 },
       ],
-      valueFormatter: (value: number) => `${value.toFixed(1)}`,
     },
     {
       title: 'Site 2',
       type: 'area' as const,
       data: [
-        { x: new Date(2023, 0, 1), y: 2 },
-        { x: new Date(2023, 0, 2), y: 2.2 },
-        { x: new Date(2023, 0, 3), y: 2.1 },
-        { x: new Date(2023, 0, 4), y: 1.9 },
-        { x: new Date(2023, 0, 5), y: 2.3 },
-        { x: new Date(2023, 0, 6), y: 3 },
-        { x: new Date(2023, 0, 7), y: 3.5 },
-        { x: new Date(2023, 0, 8), y: 3.4 },
-        { x: new Date(2023, 0, 9), y: 3.2 },
-        { x: new Date(2023, 0, 10), y: 2.8 },
-        { x: new Date(2023, 0, 11), y: 2.5 },
-        { x: new Date(2023, 0, 12), y: 2.3 },
+        { x: 'x1', y: 2 },
+        { x: 'x2', y: 2.2 },
+        { x: 'x3', y: 2.1 },
+        { x: 'x4', y: 1.9 },
+        { x: 'x5', y: 2.3 },
+        { x: 'x6', y: 3 },
+        { x: 'x7', y: 3.5 },
+        { x: 'x8', y: 3.4 },
+        { x: 'x9', y: 3.2 },
+        { x: 'x10', y: 2.8 },
+        { x: 'x11', y: 2.5 },
+        { x: 'x12', y: 2.3 },
       ],
-      valueFormatter: (value: number) => `${value.toFixed(1)}`,
     },
   ];
 
@@ -52,20 +49,10 @@ export function NetworkTrafficChart() {
     <Container>
       <AreaChart
         series={series}
-        xDomain={[new Date(2023, 0, 1), new Date(2023, 0, 12)]}
-        yDomain={[0, 6]}
         height={300}
         ariaLabel="Network traffic area chart"
         xTitle="Day"
         yTitle="Network traffic"
-        legendTitle="Legend"
-        i18nStrings={{
-          xTickFormatter: (value) => {
-            const date = value as Date;
-            return `x${date.getDate()}`;
-          },
-          yTickFormatter: (value) => `y${value}`,
-        }}
         hideFilter
         statusType="finished"
       />

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import React from 'react';
-import { createRoot } from 'react-dom/client';
-
-import '@cloudscape-design/global-styles/index.css';
 import { App } from './app';
 
-const root = createRoot(document.getElementById('app')!);
-root.render(<App />);
+import '../../styles/base.scss';
+
+export default function NetworkDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import '@cloudscape-design/global-styles/index.css';
+import { App } from './app';
+
+const root = createRoot(document.getElementById('app')!);
+root.render(<App />);

--- a/src/pages/network-dashboard/styles.css
+++ b/src/pages/network-dashboard/styles.css
@@ -1,0 +1,9 @@
+.pagination-controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.search-pagination-wrapper {
+  width: 100%;
+}


### PR DESCRIPTION
### Purpose

The user wanted to create a new dashboard page based on a Figma design. The goal was to build a responsive page that displays network traffic, credit usage, and device information, while also addressing a runtime error.

### Code changes

- **New Dashboard Page:** A new page has been added at `/network-dashboard` to serve as a network administration dashboard.
- **Component-Based Architecture:** The dashboard is built with several new React components:
    - `NetworkTrafficChart`: An area chart to visualize network traffic.
    - `CreditUsageChart`: A bar chart for displaying credit usage.
    - `DevicesTable`: A table for listing and managing network devices.
- **Routing:** The new dashboard is now accessible via a new route and is listed on the main demos page.
- **Styling:** Added custom CSS to ensure the proper layout and responsiveness of the dashboard components.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/514d22a1cb1b447296fd2a00d4173016/spark-landing)

👀 [Preview Link](https://514d22a1cb1b447296fd2a00d4173016-spark-landing.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>514d22a1cb1b447296fd2a00d4173016</projectId>-->
<!--<branchName>spark-landing</branchName>-->