### PR TITLE
Add network administration dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/network-admin-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic, credit usage, and devices dashboard.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/network-admin-dashboard/app.tsx
+++ b/src/pages/network-admin-dashboard/app.tsx
@@ -2,23 +2,22 @@
 // SPDX-License-Identifier: MIT-0
 import React, { useState } from 'react';
 
-import AppLayout from '@cloudscape-design/components/app-layout';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
 import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
 import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
 import Flashbar from '@cloudscape-design/components/flashbar';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
 import LineChart from '@cloudscape-design/components/line-chart';
-import BarChart from '@cloudscape-design/components/bar-chart';
 import Pagination from '@cloudscape-design/components/pagination';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Table from '@cloudscape-design/components/table';
 import TextFilter from '@cloudscape-design/components/text-filter';
-import Box from '@cloudscape-design/components/box';
-import Container from '@cloudscape-design/components/container';
 
-import { Navigation } from '../commons/common-components';
-import { networkTrafficSeries, creditUsageSeries, devicesData } from './data';
+import { CustomAppLayout, Navigation } from '../commons/common-components';
+import { creditUsageSeries, devicesData, networkTrafficSeries } from './data';
 
 export function App() {
   const [filteringText, setFilteringText] = useState('');
@@ -64,7 +63,7 @@ export function App() {
   ];
 
   return (
-    <AppLayout
+    <CustomAppLayout
       navigation={<Navigation activeHref="#/network-admin-dashboard" />}
       toolsHide
       content={

--- a/src/pages/network-admin-dashboard/app.tsx
+++ b/src/pages/network-admin-dashboard/app.tsx
@@ -1,0 +1,229 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import LineChart from '@cloudscape-design/components/line-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Pagination from '@cloudscape-design/components/pagination';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Box from '@cloudscape-design/components/box';
+import Container from '@cloudscape-design/components/container';
+
+import { Navigation } from '../commons/common-components';
+import { networkTrafficSeries, creditUsageSeries, devicesData } from './data';
+
+export function App() {
+  const [filteringText, setFilteringText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [showBanner, setShowBanner] = useState(true);
+
+  const columnDefinitions = [
+    {
+      id: 'column1',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column1,
+    },
+    {
+      id: 'column2',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column2,
+    },
+    {
+      id: 'column3',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column3,
+    },
+    {
+      id: 'column4',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column4,
+    },
+    {
+      id: 'column5',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column5,
+    },
+    {
+      id: 'column6',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column6,
+    },
+    {
+      id: 'column7',
+      header: 'Column header',
+      cell: (item: typeof devicesData[0]) => item.column7,
+    },
+  ];
+
+  return (
+    <AppLayout
+      navigation={<Navigation activeHref="#/network-admin-dashboard" />}
+      toolsHide
+      content={
+        <SpaceBetween size="l">
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#' },
+              { text: 'Administrative Dashboard', href: '#' },
+            ]}
+            ariaLabel="Breadcrumbs"
+          />
+
+          <Header
+            variant="h1"
+            description="Network Traffic, Credit Usage, and Your Devices"
+            actions={
+              <Button variant="primary" iconName="refresh">
+                Refresh Data
+              </Button>
+            }
+          >
+            Network Administration Dashboard
+          </Header>
+
+          <SpaceBetween size="m">
+            <div className="search-pagination-wrapper">
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+                <TextFilter
+                  filteringText={filteringText}
+                  onChange={({ detail }) => setFilteringText(detail.filteringText)}
+                  filteringPlaceholder="Placeholder"
+                />
+                <div className="pagination-controls">
+                  <Pagination
+                    currentPageIndex={currentPageIndex}
+                    onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                    pagesCount={5}
+                  />
+                  <Button variant="icon" iconName="settings" />
+                </div>
+              </Grid>
+            </div>
+
+            {showBanner && (
+              <Flashbar
+                items={[
+                  {
+                    type: 'warning',
+                    dismissible: true,
+                    content: 'This is a warning message',
+                    onDismiss: () => setShowBanner(false),
+                    buttonText: 'Dismiss',
+                    id: 'warning-message',
+                  },
+                ]}
+              />
+            )}
+
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <Container>
+                <LineChart
+                  series={networkTrafficSeries}
+                  xDomain={[0, 12]}
+                  yDomain={[0, 6]}
+                  height={300}
+                  hideFilter
+                  statusType="finished"
+                  detailPopoverSize="medium"
+                  xTitle="Day"
+                  yTitle="y"
+                  ariaLabel="Network traffic"
+                  i18nStrings={{
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'line chart',
+                    xTickFormatter: (value) => `x${value + 1}`,
+                    yTickFormatter: (value) => `y${value}`,
+                  }}
+                  legendTitle="Network traffic"
+                />
+                <Box variant="small" color="text-body-secondary" margin={{ top: 's' }}>
+                  <SpaceBetween direction="horizontal" size="m">
+                    <div className="chart-legend-item">
+                      <span className="legend-marker site-1"></span>
+                      Site 1
+                    </div>
+                    <div className="chart-legend-item">
+                      <span className="legend-marker site-2"></span>
+                      Site 2
+                    </div>
+                    <div className="chart-legend-item">
+                      <span className="legend-marker performance-goal"></span>
+                      Performance goal
+                    </div>
+                  </SpaceBetween>
+                </Box>
+              </Container>
+
+              <Container>
+                <BarChart
+                  series={creditUsageSeries}
+                  xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+                  yDomain={[0, 6]}
+                  height={300}
+                  hideFilter
+                  statusType="finished"
+                  xTitle="Day"
+                  yTitle="y"
+                  ariaLabel="Credit usage"
+                  i18nStrings={{
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    yTickFormatter: (value) => `y${value}`,
+                  }}
+                  legendTitle="Credit Usage"
+                />
+                <Box variant="small" color="text-body-secondary" margin={{ top: 's' }}>
+                  <SpaceBetween direction="horizontal" size="m">
+                    <div className="chart-legend-item">
+                      <span className="legend-marker site-1"></span>
+                      Site 1
+                    </div>
+                    <div className="chart-legend-item">
+                      <span className="legend-marker performance-goal"></span>
+                      Performance goal
+                    </div>
+                  </SpaceBetween>
+                </Box>
+              </Container>
+            </Grid>
+
+            <Header
+              variant="h2"
+              description="Devices on your local network"
+              actions={
+                <Button variant="primary" iconName="add-plus">
+                  Add Device
+                </Button>
+              }
+            >
+              My Devices
+            </Header>
+
+            <Table
+              columnDefinitions={columnDefinitions}
+              items={devicesData}
+              selectionType="multi"
+              variant="container"
+              empty={
+                <Box textAlign="center" color="inherit">
+                  <b>No devices</b>
+                  <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                    No devices to display.
+                  </Box>
+                </Box>
+              }
+            />
+          </SpaceBetween>
+        </SpaceBetween>
+      }
+    />
+  );
+}

--- a/src/pages/network-admin-dashboard/app.tsx
+++ b/src/pages/network-admin-dashboard/app.tsx
@@ -28,37 +28,37 @@ export function App() {
     {
       id: 'column1',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column1,
+      cell: (item: (typeof devicesData)[0]) => item.column1,
     },
     {
       id: 'column2',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column2,
+      cell: (item: (typeof devicesData)[0]) => item.column2,
     },
     {
       id: 'column3',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column3,
+      cell: (item: (typeof devicesData)[0]) => item.column3,
     },
     {
       id: 'column4',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column4,
+      cell: (item: (typeof devicesData)[0]) => item.column4,
     },
     {
       id: 'column5',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column5,
+      cell: (item: (typeof devicesData)[0]) => item.column5,
     },
     {
       id: 'column6',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column6,
+      cell: (item: (typeof devicesData)[0]) => item.column6,
     },
     {
       id: 'column7',
       header: 'Column header',
-      cell: (item: typeof devicesData[0]) => item.column7,
+      cell: (item: (typeof devicesData)[0]) => item.column7,
     },
   ];
 
@@ -140,8 +140,8 @@ export function App() {
                     i18nStrings={{
                       legendAriaLabel: 'Legend',
                       chartAriaRoleDescription: 'area chart',
-                      xTickFormatter: (value) => `x${Math.floor(value) + 1}`,
-                      yTickFormatter: (value) => `y${value}`,
+                      xTickFormatter: value => `x${Math.floor(value) + 1}`,
+                      yTickFormatter: value => `y${value}`,
                     }}
                   />
                   <Box variant="small" color="text-body-secondary">
@@ -179,7 +179,7 @@ export function App() {
                     i18nStrings={{
                       legendAriaLabel: 'Legend',
                       chartAriaRoleDescription: 'bar chart',
-                      yTickFormatter: (value) => `y${value}`,
+                      yTickFormatter: value => `y${value}`,
                     }}
                   />
                   <Box variant="small" color="text-body-secondary">

--- a/src/pages/network-admin-dashboard/app.tsx
+++ b/src/pages/network-admin-dashboard/app.tsx
@@ -123,74 +123,78 @@ export function App() {
             )}
 
             <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-              <Container>
-                <LineChart
-                  series={networkTrafficSeries}
-                  xDomain={[0, 12]}
-                  yDomain={[0, 6]}
-                  height={300}
-                  hideFilter
-                  statusType="finished"
-                  detailPopoverSize="medium"
-                  xTitle="Day"
-                  yTitle="y"
-                  ariaLabel="Network traffic"
-                  i18nStrings={{
-                    legendAriaLabel: 'Legend',
-                    chartAriaRoleDescription: 'line chart',
-                    xTickFormatter: (value) => `x${value + 1}`,
-                    yTickFormatter: (value) => `y${value}`,
-                  }}
-                  legendTitle="Network traffic"
-                />
-                <Box variant="small" color="text-body-secondary" margin={{ top: 's' }}>
-                  <SpaceBetween direction="horizontal" size="m">
-                    <div className="chart-legend-item">
-                      <span className="legend-marker site-1"></span>
-                      Site 1
-                    </div>
-                    <div className="chart-legend-item">
-                      <span className="legend-marker site-2"></span>
-                      Site 2
-                    </div>
-                    <div className="chart-legend-item">
-                      <span className="legend-marker performance-goal"></span>
-                      Performance goal
-                    </div>
-                  </SpaceBetween>
-                </Box>
+              <Container header={<Header variant="h2">Network traffic</Header>}>
+                <SpaceBetween size="m">
+                  <LineChart
+                    series={networkTrafficSeries}
+                    xDomain={[0, 11]}
+                    yDomain={[0, 6]}
+                    height={280}
+                    hideFilter
+                    hideLegend
+                    statusType="finished"
+                    detailPopoverSize="medium"
+                    xTitle="Day"
+                    yTitle=""
+                    ariaLabel="Network traffic"
+                    i18nStrings={{
+                      legendAriaLabel: 'Legend',
+                      chartAriaRoleDescription: 'area chart',
+                      xTickFormatter: (value) => `x${Math.floor(value) + 1}`,
+                      yTickFormatter: (value) => `y${value}`,
+                    }}
+                  />
+                  <Box variant="small" color="text-body-secondary">
+                    <SpaceBetween direction="horizontal" size="m">
+                      <div className="chart-legend-item">
+                        <span className="legend-marker site-1"></span>
+                        Site 1
+                      </div>
+                      <div className="chart-legend-item">
+                        <span className="legend-marker site-2"></span>
+                        Site 2
+                      </div>
+                      <div className="chart-legend-item">
+                        <span className="legend-marker performance-goal"></span>
+                        Performance goal
+                      </div>
+                    </SpaceBetween>
+                  </Box>
+                </SpaceBetween>
               </Container>
 
-              <Container>
-                <BarChart
-                  series={creditUsageSeries}
-                  xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
-                  yDomain={[0, 6]}
-                  height={300}
-                  hideFilter
-                  statusType="finished"
-                  xTitle="Day"
-                  yTitle="y"
-                  ariaLabel="Credit usage"
-                  i18nStrings={{
-                    legendAriaLabel: 'Legend',
-                    chartAriaRoleDescription: 'bar chart',
-                    yTickFormatter: (value) => `y${value}`,
-                  }}
-                  legendTitle="Credit Usage"
-                />
-                <Box variant="small" color="text-body-secondary" margin={{ top: 's' }}>
-                  <SpaceBetween direction="horizontal" size="m">
-                    <div className="chart-legend-item">
-                      <span className="legend-marker site-1"></span>
-                      Site 1
-                    </div>
-                    <div className="chart-legend-item">
-                      <span className="legend-marker performance-goal"></span>
-                      Performance goal
-                    </div>
-                  </SpaceBetween>
-                </Box>
+              <Container header={<Header variant="h2">Credit Usage</Header>}>
+                <SpaceBetween size="m">
+                  <BarChart
+                    series={creditUsageSeries}
+                    xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+                    yDomain={[0, 6]}
+                    height={280}
+                    hideFilter
+                    hideLegend
+                    statusType="finished"
+                    xTitle="Day"
+                    yTitle=""
+                    ariaLabel="Credit usage"
+                    i18nStrings={{
+                      legendAriaLabel: 'Legend',
+                      chartAriaRoleDescription: 'bar chart',
+                      yTickFormatter: (value) => `y${value}`,
+                    }}
+                  />
+                  <Box variant="small" color="text-body-secondary">
+                    <SpaceBetween direction="horizontal" size="m">
+                      <div className="chart-legend-item">
+                        <span className="legend-marker bar-site-1"></span>
+                        Site 1
+                      </div>
+                      <div className="chart-legend-item">
+                        <span className="legend-marker performance-goal"></span>
+                        Performance goal
+                      </div>
+                    </SpaceBetween>
+                  </Box>
+                </SpaceBetween>
               </Container>
             </Grid>
 

--- a/src/pages/network-admin-dashboard/app.tsx
+++ b/src/pages/network-admin-dashboard/app.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 import React, { useState } from 'react';
 
+import AreaChart from '@cloudscape-design/components/area-chart';
 import BarChart from '@cloudscape-design/components/bar-chart';
 import Box from '@cloudscape-design/components/box';
 import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
@@ -10,7 +11,6 @@ import Container from '@cloudscape-design/components/container';
 import Flashbar from '@cloudscape-design/components/flashbar';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
-import LineChart from '@cloudscape-design/components/line-chart';
 import Pagination from '@cloudscape-design/components/pagination';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Table from '@cloudscape-design/components/table';
@@ -125,7 +125,7 @@ export function App() {
             <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
               <Container header={<Header variant="h2">Network traffic</Header>}>
                 <SpaceBetween size="m">
-                  <LineChart
+                  <AreaChart
                     series={networkTrafficSeries}
                     xDomain={[0, 11]}
                     yDomain={[0, 6]}

--- a/src/pages/network-admin-dashboard/data.ts
+++ b/src/pages/network-admin-dashboard/data.ts
@@ -3,11 +3,11 @@
 import { LineChartProps } from '@cloudscape-design/components/line-chart';
 import { BarChartProps } from '@cloudscape-design/components/bar-chart';
 
-// Network traffic data (area chart)
+// Network traffic data (area chart - using line type with area styling)
 export const networkTrafficSeries: LineChartProps<number>['series'] = [
   {
     title: 'Site 1',
-    type: 'area',
+    type: 'line',
     data: [
       { x: 0, y: 3 },
       { x: 1, y: 3.2 },
@@ -22,11 +22,11 @@ export const networkTrafficSeries: LineChartProps<number>['series'] = [
       { x: 10, y: 4.8 },
       { x: 11, y: 4.2 },
     ],
-    valueFormatter: (value) => value.toFixed(1),
+    valueFormatter: (value: number) => value.toFixed(1),
   },
   {
     title: 'Site 2',
-    type: 'area',
+    type: 'line',
     data: [
       { x: 0, y: 2 },
       { x: 1, y: 2.1 },
@@ -41,13 +41,13 @@ export const networkTrafficSeries: LineChartProps<number>['series'] = [
       { x: 10, y: 3.2 },
       { x: 11, y: 2.8 },
     ],
-    valueFormatter: (value) => value.toFixed(1),
+    valueFormatter: (value: number) => value.toFixed(1),
   },
   {
     title: 'Performance goal',
     type: 'threshold',
     y: 3.3,
-    valueFormatter: (value) => value.toFixed(1),
+    valueFormatter: (value: number) => value.toFixed(1),
   },
 ];
 
@@ -63,7 +63,7 @@ export const creditUsageSeries: BarChartProps<string>['series'] = [
       { x: 'x4', y: 3 },
       { x: 'x5', y: 5 },
     ],
-    valueFormatter: (value) => value.toFixed(1),
+    valueFormatter: (value: number) => value.toFixed(1),
   },
 ];
 

--- a/src/pages/network-admin-dashboard/data.ts
+++ b/src/pages/network-admin-dashboard/data.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import { LineChartProps } from '@cloudscape-design/components/line-chart';
+import { BarChartProps } from '@cloudscape-design/components/bar-chart';
+
+// Network traffic data (area chart)
+export const networkTrafficSeries: LineChartProps<number>['series'] = [
+  {
+    title: 'Site 1',
+    type: 'area',
+    data: [
+      { x: 0, y: 3 },
+      { x: 1, y: 3.2 },
+      { x: 2, y: 3.5 },
+      { x: 3, y: 3.8 },
+      { x: 4, y: 4.2 },
+      { x: 5, y: 4.5 },
+      { x: 6, y: 4.8 },
+      { x: 7, y: 5.2 },
+      { x: 8, y: 5.5 },
+      { x: 9, y: 5.3 },
+      { x: 10, y: 4.8 },
+      { x: 11, y: 4.2 },
+    ],
+    valueFormatter: (value) => value.toFixed(1),
+  },
+  {
+    title: 'Site 2',
+    type: 'area',
+    data: [
+      { x: 0, y: 2 },
+      { x: 1, y: 2.1 },
+      { x: 2, y: 2.3 },
+      { x: 3, y: 2.5 },
+      { x: 4, y: 2.8 },
+      { x: 5, y: 3.0 },
+      { x: 6, y: 3.2 },
+      { x: 7, y: 3.5 },
+      { x: 8, y: 3.7 },
+      { x: 9, y: 3.5 },
+      { x: 10, y: 3.2 },
+      { x: 11, y: 2.8 },
+    ],
+    valueFormatter: (value) => value.toFixed(1),
+  },
+  {
+    title: 'Performance goal',
+    type: 'threshold',
+    y: 3.3,
+    valueFormatter: (value) => value.toFixed(1),
+  },
+];
+
+// Credit usage data (bar chart)
+export const creditUsageSeries: BarChartProps<string>['series'] = [
+  {
+    title: 'Site 1',
+    type: 'bar',
+    data: [
+      { x: 'x1', y: 4 },
+      { x: 'x2', y: 5.5 },
+      { x: 'x3', y: 5 },
+      { x: 'x4', y: 3 },
+      { x: 'x5', y: 5 },
+    ],
+    valueFormatter: (value) => value.toFixed(1),
+  },
+];
+
+// Devices table data
+export const devicesData = Array.from({ length: 12 }, (_, index) => ({
+  id: `device-${index + 1}`,
+  column1: 'Cell Value',
+  column2: 'Cell Value',
+  column3: 'Cell Value',
+  column4: 'Cell Value',
+  column5: 'Cell Value',
+  column6: 'Cell Value',
+  column7: 'Cell Value',
+}));

--- a/src/pages/network-admin-dashboard/data.ts
+++ b/src/pages/network-admin-dashboard/data.ts
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
-import { LineChartProps } from '@cloudscape-design/components/line-chart';
+import { AreaChartProps } from '@cloudscape-design/components/area-chart';
 import { BarChartProps } from '@cloudscape-design/components/bar-chart';
 
-// Network traffic data (area chart - using line type with area styling)
-export const networkTrafficSeries: LineChartProps<number>['series'] = [
+// Network traffic data (area chart)
+export const networkTrafficSeries: AreaChartProps<number>['series'] = [
   {
     title: 'Site 1',
-    type: 'line',
+    type: 'area',
     data: [
       { x: 0, y: 3 },
       { x: 1, y: 3.2 },
@@ -26,7 +26,7 @@ export const networkTrafficSeries: LineChartProps<number>['series'] = [
   },
   {
     title: 'Site 2',
-    type: 'line',
+    type: 'area',
     data: [
       { x: 0, y: 2 },
       { x: 1, y: 2.1 },

--- a/src/pages/network-admin-dashboard/index.tsx
+++ b/src/pages/network-admin-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+import './styles.scss';
+
+export default function NetworkAdminDashboard() {
+  return <App />;
+}

--- a/src/pages/network-admin-dashboard/styles.scss
+++ b/src/pages/network-admin-dashboard/styles.scss
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.search-pagination-wrapper {
+  .pagination-controls {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+}
+
+.chart-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+
+  .legend-marker {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+
+    &.site-1 {
+      background-color: #ec7211;
+    }
+
+    &.site-2 {
+      background-color: #5f8dd3;
+    }
+
+    &.performance-goal {
+      width: 20px;
+      height: 2px;
+      border-radius: 0;
+      background-color: #000;
+      border-top: 2px dashed #000;
+    }
+  }
+}

--- a/src/pages/network-admin-dashboard/styles.scss
+++ b/src/pages/network-admin-dashboard/styles.scss
@@ -23,10 +23,14 @@
     border-radius: 2px;
 
     &.site-1 {
-      background-color: #ec7211;
+      background-color: #d13212;
     }
 
     &.site-2 {
+      background-color: #5f8dd3;
+    }
+
+    &.bar-site-1 {
       background-color: #5f8dd3;
     }
 


### PR DESCRIPTION
# Summary
This PR implements the new "Network Administration Dashboard" page, featuring responsive charts and data tables based on the provided design specifications.

# Problem
The project lacked the visual interface for monitoring network traffic, credit usage, and device management as specified in the Figma design.

# Solution
I added a new dashboard route using Cloudscape components to ensure responsiveness and consistency. The layout includes an Area Chart for traffic, a Bar Chart for credits, and a table for device management.

# Key Changes
- Created `NetworkAdminDashboard` component with `CustomAppLayout`.
- Integrated `AreaChart` and `BarChart` with custom data series.
- Added a `Table` component for device listing with column definitions.
- Implemented responsive grid layout and breadcrumb navigation.
- Added SCSS for custom legend markers and layout adjustments.

# Files Changed
- `src/pages/index.tsx`: Added route entry for `/network-admin-dashboard`.
- `src/pages/network-admin-dashboard/app.tsx`: Main dashboard UI logic and component composition.
- `src/pages/network-admin-dashboard/data.ts`: Added mock data for charts and tables.
- `src/pages/network-admin-dashboard/styles.scss`: Added specific styles for chart legends and pagination alignment.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/514d22a1cb1b447296fd2a00d4173016/glow-space)

👀 [Preview Link](https://514d22a1cb1b447296fd2a00d4173016-glow-space.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>514d22a1cb1b447296fd2a00d4173016</projectId>-->
<!--<branchName>glow-space</branchName>-->